### PR TITLE
Alter users events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,10 +9,13 @@ class EventsController < ApplicationController
 
   def create
     @event = Event.new(event_params)
-    @event.trail_id = trail_params_id
-    @event.user_id = current_user.id
-    @event.save
-    redirect_to event_path(@event)
+    if @event.save
+      current_user.hosting << @event
+      flash[:success] = ["Event Created"]
+      redirect_to event_path(@event)
+    else
+      render :new
+    end
   end
 
   def show
@@ -21,10 +24,10 @@ class EventsController < ApplicationController
 
   private
     def event_params
-      params.require(:event).permit(:name, :description, "date(1i)", "date(2i)", "date(3i)", "date(4i)", "date(5i)")
+      params.require(:event).permit(:name, :description, "date(1i)", "date(2i)", "date(3i)", "date(4i)", "date(5i)").merge(trail_params)
     end
 
-    def trail_params_id
-      params.require(:trail_id)
+    def trail_params
+      params.permit(:trail_id)
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,10 @@
 class Event < ApplicationRecord
   belongs_to :trail
-  belongs_to :host, class_name: "User", foreign_key: "user_id"
-  validates :name, :description, :date, :user_id, presence: true
+  validates :name, :description, :date, presence: true
+
+  has_many :event_guests
+  has_many :guests, :through => :event_guests, source: :guest
+
+  has_many :event_hosts
+  has_many :hosts, :through => :event_hosts, source: :host
 end

--- a/app/models/event_guest.rb
+++ b/app/models/event_guest.rb
@@ -1,0 +1,5 @@
+class EventGuest < ApplicationRecord
+  belongs_to :event
+  # belongs_to :guest, foreign_key: 'guest_id'
+  belongs_to :guest, :class_name => 'User', :foreign_key => 'guest_id'
+end

--- a/app/models/event_guest.rb
+++ b/app/models/event_guest.rb
@@ -1,5 +1,4 @@
 class EventGuest < ApplicationRecord
   belongs_to :event
-  # belongs_to :guest, foreign_key: 'guest_id'
   belongs_to :guest, :class_name => 'User', :foreign_key => 'guest_id'
 end

--- a/app/models/event_host.rb
+++ b/app/models/event_host.rb
@@ -1,0 +1,4 @@
+class EventHost < ApplicationRecord
+  belongs_to :event
+  belongs_to :host, :class_name => 'User', :foreign_key => 'host_id'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,18 @@
 class User < ApplicationRecord
   has_secure_password
   before_save :generate_slug
-  mount_uploader :image, ImageUploader
+  mount_uploader :image, ImageUploader  
   validates :email, presence: true, uniqueness: true
   validates :username, presence: true, uniqueness: true
   validates :slug, uniqueness: true
   has_one :picture, as: :imageable
+
+  has_many :event_guests, :foreign_key => 'guest_id' 
+  has_many :attending, :through => :event_guests, source: :event
+
+  has_many :event_hosts, :foreign_key => 'host_id'
+  has_many :hosting, :through => :event_hosts, source: :event
+
   accepts_nested_attributes_for :picture
 
   enum role: %w(admin)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,13 @@
 class User < ApplicationRecord
   has_secure_password
   before_save :generate_slug
+  
   mount_uploader :image, ImageUploader  
+
   validates :email, presence: true, uniqueness: true
   validates :username, presence: true, uniqueness: true
   validates :slug, uniqueness: true
+  
   has_one :picture, as: :imageable
 
   has_many :event_guests, :foreign_key => 'guest_id' 
@@ -26,6 +29,6 @@ class User < ApplicationRecord
   end
 
   def generate_slug
-    self.slug = username.parameterize
+    self.slug = username.parameterize if username
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,7 +7,10 @@ Trail Distance: <%= @event.trail.distance %>
 Trail Rating: <%= @event.trail.rating %>
 <br>
 <div>Event details:</div>
-Hosted by <%= @event.host.username %>
+Hosted by:  
+<% @event.hosts.each do |host| %>
+<%= host.username%>
+<%end%>
 Event Name: <%= @event.name %>
 Event Description: <%= @event.description %>
 Event Date: <%= @event.date %>

--- a/db/migrate/20170714221400_remove_user_id_from_events.rb
+++ b/db/migrate/20170714221400_remove_user_id_from_events.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromEvents < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :events, :user_id, :int
+  end
+end

--- a/db/migrate/20170714230036_create_join_table_events_guests.rb
+++ b/db/migrate/20170714230036_create_join_table_events_guests.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableEventsGuests < ActiveRecord::Migration[5.1]
+  def change
+    create_table :event_guests do |t|
+      t.references :event, foreign_key: true
+      t.references :guest
+    end
+  end
+end

--- a/db/migrate/20170714230051_create_join_table_events_hosts.rb
+++ b/db/migrate/20170714230051_create_join_table_events_hosts.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableEventsHosts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :event_hosts do |t|
+      t.references :event, foreign_key: true
+      t.references :host
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713174408) do
+ActiveRecord::Schema.define(version: 20170714230051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "event_guests", force: :cascade do |t|
+    t.bigint "event_id"
+    t.bigint "guest_id"
+    t.index ["event_id"], name: "index_event_guests_on_event_id"
+    t.index ["guest_id"], name: "index_event_guests_on_guest_id"
+  end
+
+  create_table "event_hosts", force: :cascade do |t|
+    t.bigint "event_id"
+    t.bigint "host_id"
+    t.index ["event_id"], name: "index_event_hosts_on_event_id"
+    t.index ["host_id"], name: "index_event_hosts_on_host_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.bigint "trail_id"
@@ -22,9 +36,7 @@ ActiveRecord::Schema.define(version: 20170713174408) do
     t.datetime "date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
     t.index ["trail_id"], name: "index_events_on_trail_id"
-    t.index ["user_id"], name: "index_events_on_user_id"
   end
 
   create_table "pictures", force: :cascade do |t|
@@ -59,6 +71,7 @@ ActiveRecord::Schema.define(version: 20170713174408) do
     t.integer "role"
   end
 
+  add_foreign_key "event_guests", "events"
+  add_foreign_key "event_hosts", "events"
   add_foreign_key "events", "trails"
-  add_foreign_key "events", "users"
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :event do
-    trail nil
+    trail
     name "Event Name"
     description "Event Description"
     date "2017-07-12 18:57:17"

--- a/spec/features/guests/guest_can_search_events_from_landing_page_spec.rb
+++ b/spec/features/guests/guest_can_search_events_from_landing_page_spec.rb
@@ -1,19 +1,19 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe "As a guest" do
-  it "can search fro an event from the landing page" do
+# RSpec.describe "As a guest" do
+#   it "can search fro an event from the landing page" do
 
-    event_one = create(:event)
+#     event_one = create(:event)
 
-    visit root_path
-    fill_in :search, with: "80210"
-    expect(current_path).to eq(events_search_path)
-    expect(page).to have_content(event_one.name)
-    expect(page).to have_content(event_one.description)
-    expect(page).to have_content(event_one.date)
-    expect(page).to have_content(event_one.trail)
-  end
+#     visit root_path
+#     fill_in :search, with: "80210"
+#     expect(current_path).to eq(events_search_path)
+#     expect(page).to have_content(event_one.name)
+#     expect(page).to have_content(event_one.description)
+#     expect(page).to have_content(event_one.date)
+#     expect(page).to have_content(event_one.trail)
+#   end
 
-end
+# end
 
 

--- a/spec/features/guests/guest_can_search_events_from_landing_page_spec.rb
+++ b/spec/features/guests/guest_can_search_events_from_landing_page_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "As a guest" do
+  it "can search fro an event from the landing page" do
+
+    event_one = create(:event)
+
+    visit root_path
+    fill_in :search, with: "80210"
+    expect(current_path).to eq(events_search_path)
+    expect(page).to have_content(event_one.name)
+    expect(page).to have_content(event_one.description)
+    expect(page).to have_content(event_one.date)
+    expect(page).to have_content(event_one.trail)
+  end
+
+end
+
+

--- a/spec/features/users/user_can_create_event_spec.rb
+++ b/spec/features/users/user_can_create_event_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "User creates an event" do
     click_on "Publish Event"
 
     expect(current_path).to eq(event_path(Event.first))
-    expect(page).to have_content("Hosted by #{user.username}")
+    expect(page).to have_content("Hosted by: #{user.username}")
     expect(page).to have_content("Halloween Epic Trail Hike")
     expect(page).to have_content("A spooky hike on an epic trail!")
     expect(page).to have_content("2017-10-31 23:59:00")

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,68 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
-
-  let(:trail) do
-    Trail.create(name: "Awesome Trail",
-                 description: "This Trail is Amazing!",
-                 difficulty: "Double Black Diamond",
-                 location: "Boulder, CO",
-                 distance: 22.5,
-                 rating: 5.0,
-                 long: 30.000,
-                 lat: -100.000)
-  end
-
-  let(:host) do
-    User.create(username: "Host Name", email: "example@gmail.com", password: "password")
-  end
-
-  it "has name, description, date, trail, and host attributes" do
-    event = Event.create(trail_id: trail.id,
-                         user_id: host.id,
-                         name: "Event Name",
-                         description: "Event Description",
-                         date: "2017-07-12 18:57:17")
-    expect(event).to be_valid
-  end
-
-  it "must belong to a trail" do
-    no_trail_event = Event.create(user_id: host.id,
-                                  name: "Event Name",
-                                  description: "Event Description",
-                                  date: "2017-07-12 18:57:17")
-    expect(no_trail_event).not_to be_valid
-  end
-
-  it "must belong to a host" do
-    no_host_event = Event.create(trail_id: trail.id,
-                                 name: "Event Name",
-                                 description: "Event Description",
-                                 date: "2017-07-12 18:57:17")
-    expect(no_host_event).not_to be_valid
-  end
-
-  it "must have a name" do
-    no_name_event = Event.create(trail_id: trail.id,
-                                 user_id: host.id,
-                                 description: "Event Description",
-                                 date: "2017-07-12 18:57:17")
-    expect(no_name_event).not_to be_valid
-  end
-
-  it "must have a description" do
-    no_description_event = Event.create(trail_id: trail.id,
-                                        user_id: host.id,
-                                        name: "Event Name",
-                                        date: "2017-07-12 18:57:17")
-    expect(no_description_event).not_to be_valid
-  end
-
-  it "must have a date" do
-    no_date_event = Event.create(trail_id: trail.id,
-                                 user_id: host.id,
-                                 name: "Event Name",
-                                 description: "Event Description")
-    expect(no_date_event).not_to be_valid
-  end
+  it {should validate_presence_of(:name)}
+  it {should validate_presence_of(:description)}
+  it {should validate_presence_of(:date)}
+  it {should belong_to(:trail)}
+  it {should have_many(:event_guests)}
+  it {should have_many(:guests).through(:event_guests).source(:guest)}
+  it {should have_many(:event_hosts)}
+  it {should have_many(:hosts).through(:event_hosts).source(:host)}
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,4 +27,5 @@ RSpec.describe User, type: :model do
     invalid_user = User.create(username: "User Name1", email: "example@gmail.com", password: "password")
     expect(invalid_user).not_to be_valid
   end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,31 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it "must have a password attribute" do
-    user = User.create(username: "User Name", email: "example@gmail.com")
-    expect(user).not_to be_valid
-  end
-
-  it "must have a username attribute" do
-    user = User.create(email: "example@gmail.com", password: "password")
-    expect(user).not_to be_valid
-  end
-
-  it "must have a email attribute" do
-    user = User.create(username: "User Name", password: "password")
-    expect(user).not_to be_valid
-  end
-
-  it "must have a unique username attribute" do
-    valid_user = User.create(username: "User Name", email: "example@gmail.com", password: "password")
-    invalid_user = User.create(username: "User Name", email: "example1@gmail.com", password: "password")
-    expect(invalid_user).not_to be_valid
-  end
-
-  it "must have a unique email attribute" do
-    valid_user = User.create(username: "User Name", email: "example@gmail.com", password: "password")
-    invalid_user = User.create(username: "User Name1", email: "example@gmail.com", password: "password")
-    expect(invalid_user).not_to be_valid
-  end
+  it {should have_secure_password}
+  it {should validate_presence_of(:username)}
+  it {should validate_uniqueness_of(:username)}
+  it {should validate_presence_of(:email)}
+  it {should validate_uniqueness_of(:email)}
+  it {should have_one(:picture)}
+  it {should accept_nested_attributes_for(:picture)}
+  it {should have_many(:event_guests)}
+  it {should have_many(:attending).through(:event_guests).source(:event)}
+  it {should have_many(:event_hosts)}
+  it {should have_many(:hosting).through(:event_hosts).source(:event)}
+  
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,4 @@ RSpec.describe User, type: :model do
   it {should have_many(:attending).through(:event_guests).source(:event)}
   it {should have_many(:event_hosts)}
   it {should have_many(:hosting).through(:event_hosts).source(:event)}
-  
-
 end


### PR DESCRIPTION
#### What does  this PR do?
This PR changes the relationship between users and events so that events can have guests and hosts that are both on the user table.
#####NOTE:
You can now retrieve information by the following methods:
user.hosting     => collection of events where user is the host
user.attending  => collection of events where user is the guest
event.hosts      => collections of users associated as host on event
event.guests    => collections of users associated as guest on event

#### Where should the reviewer start?
The reviewer should start on the event and user models, in addition to the event_guest and event_host models to see what the new associations are.

#### How should this be manually tested?
Besides running the test suite the review can confirm by playing with these new associations in the console.

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? 
YES
  - Do Environment Variables need to be set? 
No
  - Any other deploy steps? 
No