### PR TITLE
Globalize Google Api Key

### DIFF
--- a/spec/features/users/user_can_create_event_spec.rb
+++ b/spec/features/users/user_can_create_event_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe "User creates an event" do
   scenario "user creates an event from a new trail" do
-    binding.pry
     user = create(:user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 


### PR DESCRIPTION
Fixes a failed merge from previous Globalize Google Api Key PR. 

Also added rake vcr:scrub to reset vcr directory.
